### PR TITLE
app.js: Try alternate port if 8080 is unavailable

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,21 @@
 const express = require('express');
 const { main, isLoomVideoUrl } = require('./download');
 const app = express();
-const port = 8080;
+let port = 8080;
+
+const server = app.listen(port, () => {
+    console.log(`Server is running on http://localhost:${port}`);
+});
+
+// Check if port is in use and set to a different port if necessary
+server.on('error', (err) => {
+    if (err.code === 'EADDRINUSE') {
+        port++;
+        console.log(`Port 8080 in use, switching to port ${port}`);
+        server.close(); // Close the previous server
+        server.listen(port); // Start a new server on the new port
+    }
+});
 
 app.use(express.json());
 
@@ -14,9 +28,4 @@ app.post('/download-video', async (req, res) => {
 
     const response = await main(url);
     return res.json(response);
-});
-
-// Start the server
-app.listen(port, () => {
-    console.log(`Server is running on http://localhost:${port}`);
 });


### PR DESCRIPTION
Updated the start server functionality to check if the default port 8080 is unavailable (in use by a different app) and use a different one and print the new port